### PR TITLE
Tie snapping to grid size and adjust grid size

### DIFF
--- a/Assets/_scenes/InitialDevelopment.unity
+++ b/Assets/_scenes/InitialDevelopment.unity
@@ -444,7 +444,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e186178919078724fa0b64af7b0b328e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gridSize: 0.2
+  gridSize: 0.1
   cursor: {fileID: 1448697239}
   pointer: {fileID: 2028207515}
   inputManager: {fileID: 689483602}

--- a/Assets/_scripts/TransformSnap.cs
+++ b/Assets/_scripts/TransformSnap.cs
@@ -12,7 +12,9 @@ public class TransformSnap
 	
 	private static GameObject transformHolder = new GameObject();
 	
-	public static TransformSnap SnapToClosest(GameObject subject, List<GameObject> targets, float maximumSquaredDistance = 2){
+	public static TransformSnap SnapToClosest(GameObject subject, List<GameObject> targets, float maximumSquaredDistance = 0){
+		if(maximumSquaredDistance == 0)
+			maximumSquaredDistance = gridSize * gridSize * 2;
 		GameObject bestTarget = null;
         float closestDistanceSqr = Mathf.Infinity;
         Vector3 currentPosition = subject.transform.position;


### PR DESCRIPTION
Makes maximum snapping distance rely on grid size. Also reduces grid size.